### PR TITLE
use {js| and |js} to delimit strings

### DIFF
--- a/lib/yoshi.ml
+++ b/lib/yoshi.ml
@@ -34,7 +34,7 @@ module Gen = struct
 
   let rec string_of_field_value value =
     match value with
-    | `String s -> Printf.sprintf "\"%s\"" s
+    | `String s -> Printf.sprintf "{js|%s|js}" s
     | `Int i -> string_of_int i
     | `Float f -> string_of_float f
     | `Bool b -> string_of_bool b


### PR DESCRIPTION
Strings may contain the `"` character.